### PR TITLE
Fix parameters names in GET requests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,3 @@
-module github.com/artsafin/go-coda
+module github.com/phouse512/go-coda
 
 require github.com/google/go-querystring v1.0.0
-
-go 1.13

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
-module github.com/phouse512/go-coda
+module github.com/artsafin/go-coda
 
 require github.com/google/go-querystring v1.0.0
+
+go 1.13

--- a/misc.go
+++ b/misc.go
@@ -13,8 +13,8 @@ type Resource struct {
 }
 
 type ResolveBrowserLinkParameters struct {
-	Url               string `json:"url"`
-	DegradeGracefully bool   `json:"degradeGracefully"`
+	Url               string `json:"url" url:"url"`
+	DegradeGracefully bool   `json:"degradeGracefully" url:"degradeGracefully"`
 }
 
 type ResolveBrowserLinkResponse struct {

--- a/rows.go
+++ b/rows.go
@@ -30,7 +30,7 @@ type ListRowsParameters struct {
 }
 
 type GetRowParameters struct {
-	UseColumnNames bool `json:"useColumnNames"`
+	UseColumnNames bool `json:"useColumnNames" url:"useColumnNames"`
 }
 
 type ListRowsResponse struct {
@@ -79,10 +79,10 @@ type DeleteRowResponse struct {
 }
 
 type ListViewRowsParameters struct {
-	Query          string `json:"query"`
-	SortBy         string `json:"sortBy"`
-	UseColumnNames bool   `json:"useColumnNames"`
-	ValueFormat    string `json:"valueFormat"`
+	Query          string `json:"query" url:"query"`
+	SortBy         string `json:"sortBy" url:"sortBy"`
+	UseColumnNames bool   `json:"useColumnNames" url:"useColumnNames"`
+	ValueFormat    string `json:"valueFormat" url:"valueFormat"`
 	PaginationPayload
 }
 

--- a/rows.go
+++ b/rows.go
@@ -23,9 +23,9 @@ type Row struct {
 }
 
 type ListRowsParameters struct {
-	Query          string `json:"query"`
-	SortBy         string `json:"sortBy"`
-	UseColumnNames bool   `json:"useColumnNames"`
+	Query          string `json:"query" url:"query"`
+	SortBy         string `json:"sortBy" url:"sortBy"`
+	UseColumnNames bool   `json:"useColumnNames" url:"useColumnNames"`
 	PaginationPayload
 }
 


### PR DESCRIPTION
As per [Coda docs](https://coda.io/developers/apis/v1beta1#tag/Rows) there are few requests sent by GET method with parameters accepted from query string.
`go-coda`'s `Client.newRequest` function encodes GET query string using `go-querystring`'s `query.Values` ([see line 69](https://github.com/phouse512/go-coda/blob/master/main.go#L69)) function which marshals the passed structure into the result query string.

The problem here was that `query.Values` expects a `url` struct field tag to specify the name of the parameter in query string while the current version of go-coda does not provide it (only `json` tag). This results in an incorrect query string like `Query=...&SortBy=&UseColumnNames=false` - Coda just ignores all these parameters because of the incorrect name case.

My solution is just to add the `url` tag to requests sent by GET.